### PR TITLE
Anvend de enkelte sprogs eget navn for sig selv

### DIFF
--- a/resources/lang/da/lang.php
+++ b/resources/lang/da/lang.php
@@ -4,6 +4,6 @@ return [
     'da' => 'Dansk',
     'sv' => 'Svenska',
     'en' => 'English',
-    'es' => 'Spanska',
-    'nl' => 'Nederländska',
+    'es' => 'Español',
+    'nl' => 'Nederlands',
 ];


### PR DESCRIPTION
Giver det ikke mest mening hvis navnet på det enkelte sprog angives på sproget selv? Hvis nu hovedsproget var kinesisk, ville det sandsynligvis være svært for det fleste skandinaver at vælge deres aget sprog i rullegardinsmenuen.
